### PR TITLE
Remove sourcecode dependency

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,6 @@ lazy val diesel = crossProject(JSPlatform, JVMPlatform)
   .settings(sharedSettings_scalac)
   .settings(
     libraryDependencies ++= Seq(
-      "com.lihaoyi"          %%% "sourcecode"    % "0.3.0",
       "com.ibm.cloud.diesel" %%% "diesel-i18n"   % Dependencies.dieselI18nVersion,
       scalaOrganization.value  % "scala-reflect" % scalaVersion.value,
       "org.scalameta"        %%% "munit"         % "1.0.0-M7" % Test

--- a/diesel/shared/src/main/scala/diesel/Dsl.scala
+++ b/diesel/shared/src/main/scala/diesel/Dsl.scala
@@ -19,6 +19,8 @@ package diesel
 import diesel.Lexer.{RegexScanner, Scanner, Token}
 import diesel.voc.Article
 
+import diesel.i18n.DeclaringSourceName
+
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
@@ -962,33 +964,33 @@ trait Dsl {
   def hasAncestor(c: ConceptBase, p: ConceptBase): Boolean =
     getParent(c).contains(p) || subConceptsOf(p).exists(d => hasAncestor(c, d))
 
-  def concept[T: ClassTag](implicit name: sourcecode.Name): Concept[T] = {
-    val result = Concept[T](name = name.value, None)
+  def concept[T: ClassTag](implicit name: DeclaringSourceName): Concept[T] = {
+    val result = Concept[T](name = name.name, None)
     concepts :+= result
     result
   }
 
   def concept[T: ClassTag, P >: T](parent: Concept[P])(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): Concept[T] = {
-    val result = Concept[T](name = name.value, None)
+    val result = Concept[T](name = name.name, None)
     concepts :+= result
     inheritances :+= Inheritance(parent, result)
     result
   }
 
   def concept[T: ClassTag](scanner: Scanner, defaultValue: T)(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): ConceptBuilder[T, T] =
-    new ConceptBuilder(name.value, scanner, defaultValue, (value: T) => value.toString, None)
+    new ConceptBuilder(name.name, scanner, defaultValue, (value: T) => value.toString, None)
 
   def concept[T: ClassTag, P >: T](
     scanner: Scanner,
     defaultValue: T,
     parent: Option[Concept[P]]
-  )(implicit name: sourcecode.Name): ConceptBuilder[T, P] =
+  )(implicit name: DeclaringSourceName): ConceptBuilder[T, P] =
     new ConceptBuilder[T, P](
-      name.value,
+      name.name,
       scanner,
       defaultValue,
       (value: T) => value.toString,
@@ -1037,9 +1039,9 @@ trait Dsl {
   }
 
   def instance[T](concept: Concept[T])(s: String)(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): InstanceBuilder[T] =
-    new InstanceBuilder(name.value, concept, IPStr(s))
+    new InstanceBuilder(name.name, concept, IPStr(s))
 
   class InstanceBuilder[T](
     val name: String,
@@ -1066,15 +1068,15 @@ trait Dsl {
   }
 
   def phrase[T](concept: Concept[T])(production: PhraseProduction[T])(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): Phrase[T] = {
-    addPhrase(PhraseSingle(name.value, concept, production))
+    addPhrase(PhraseSingle(name.name, concept, production))
   }
 
   def phraseMultiple[T, T2](concept: Concept[T])(production: PhraseProduction[T2])(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): Phrase[T2] = {
-    addPhrase(PhraseMulti(name.value, concept, production))
+    addPhrase(PhraseMulti(name.name, concept, production))
   }
 
   private def addSyntax[T](syntax: Syntax[T]): Syntax[T] = {
@@ -1082,19 +1084,21 @@ trait Dsl {
     syntax
   }
 
-  def syntax[T](production: SyntaxProduction[T])(implicit name: sourcecode.Name): SyntaxUntyped[T] =
-    addSyntax(SyntaxUntyped(name.value, production)).asInstanceOf[SyntaxUntyped[T]]
+  def syntax[T](production: SyntaxProduction[T])(implicit
+    name: DeclaringSourceName
+  ): SyntaxUntyped[T] =
+    addSyntax(SyntaxUntyped(name.name, production)).asInstanceOf[SyntaxUntyped[T]]
 
   def syntax[T](
     concept: Concept[T],
     expression: Boolean = true
-  )(production: SyntaxProduction[T])(implicit name: sourcecode.Name): SyntaxTyped[T] =
-    addSyntax(SyntaxTyped(name.value, concept, expression, production)).asInstanceOf[SyntaxTyped[T]]
+  )(production: SyntaxProduction[T])(implicit name: DeclaringSourceName): SyntaxTyped[T] =
+    addSyntax(SyntaxTyped(name.name, concept, expression, production)).asInstanceOf[SyntaxTyped[T]]
 
   def syntaxMultiple[T, T2](concept: Concept[T])(production: SyntaxProduction[T2])(implicit
-    name: sourcecode.Name
+    name: DeclaringSourceName
   ): SyntaxMulti[T, T2] = {
-    addSyntax(SyntaxMulti(name.value, concept, production)).asInstanceOf[SyntaxMulti[T, T2]]
+    addSyntax(SyntaxMulti(name.name, concept, production)).asInstanceOf[SyntaxMulti[T, T2]]
   }
 
   private def addGenericSyntax[T](syntax: SyntaxGenericBase[T]): SyntaxGenericBase[T] = {
@@ -1103,7 +1107,7 @@ trait Dsl {
   }
 
   def genericSyntax[T: ClassTag](base: Concept[T], toProduction: Concept[T] => SyntaxProduction[T])(
-    implicit name: sourcecode.Name
+    implicit name: DeclaringSourceName
   ): SyntaxGeneric[T] = {
     genericSyntax[T](
       toProduction,
@@ -1116,16 +1120,16 @@ trait Dsl {
     accept: (Concept[T], Expressions.Types, Dsl) => Boolean =
       (_: Concept[T], _: Expressions.Types, _: Dsl) => true
   )(
-    implicit name: sourcecode.Name
+    implicit name: DeclaringSourceName
   ): SyntaxGeneric[T] = {
     var cache: Map[Concept[T], SyntaxTyped[T]] = Map()
     addGenericSyntax(SyntaxGeneric[T](
-      name.value,
+      name.name,
       accept,
       concept => {
         cache.getOrElse(
           concept, {
-            val rule = SyntaxTyped(name.value, concept, expression = true, toProduction(concept))
+            val rule = SyntaxTyped(name.name, concept, expression = true, toProduction(concept))
             cache += concept -> rule
             rule
           }
@@ -1138,7 +1142,7 @@ trait Dsl {
     base: Concept[T],
     toProduction: Concept[T] => SyntaxProduction[T2]
   )(
-    implicit name: sourcecode.Name
+    implicit name: DeclaringSourceName
   ): SyntaxGenericMulti[T, T2] = {
     genericSyntaxMultiple[T, T2](
       toProduction,
@@ -1151,16 +1155,16 @@ trait Dsl {
     accept: (Concept[T], Expressions.Types, Dsl) => Boolean =
       (_: Concept[T], _: Expressions.Types, _: Dsl) => true
   )(
-    implicit name: sourcecode.Name
+    implicit name: DeclaringSourceName
   ): SyntaxGenericMulti[T, T2] = {
     var cache: Map[Concept[T], SyntaxMulti[T, T2]] = Map()
     addGenericSyntax(SyntaxGenericMulti[T, T2](
-      name.value,
+      name.name,
       accept,
       concept => {
         cache.getOrElse(
           concept, {
-            val rule = SyntaxMulti(name.value, concept, toProduction(concept))
+            val rule = SyntaxMulti(name.name, concept, toProduction(concept))
             cache += concept -> rule
             rule
           }
@@ -1180,11 +1184,11 @@ trait Dsl {
       new AxiomBuilder(name, SPMapped(production, f))
   }
 
-  def axiom[T](concept: Concept[T])(implicit name: sourcecode.Name): AxiomBuilder[T] =
-    new AxiomBuilder(name.value, SPExprRef(concept, internalDefaultExprs))
+  def axiom[T](concept: Concept[T])(implicit name: DeclaringSourceName): AxiomBuilder[T] =
+    new AxiomBuilder(name.name, SPExprRef(concept, internalDefaultExprs))
 
-  def axiom[T](syntax: Syntax[T])(implicit name: sourcecode.Name): AxiomBuilder[T] =
-    new AxiomBuilder(name.value, SPRuleRef(syntax))
+  def axiom[T](syntax: Syntax[T])(implicit name: DeclaringSourceName): AxiomBuilder[T] =
+    new AxiomBuilder(name.name, SPRuleRef(syntax))
 
   implicit def builderToAxiom[T](builder: AxiomBuilder[T]): Axiom[T] = builder.build
 

--- a/diesel/shared/src/main/scala/diesel/voc/VocDsl.scala
+++ b/diesel/shared/src/main/scala/diesel/voc/VocDsl.scala
@@ -21,7 +21,8 @@ import diesel.Dsl.{Associativity, Instance, Phrase, SPAndN, SPStr, Syntax, Conce
 import diesel.Lexer.Token
 import diesel.voc.Ast.DslConceptKey
 import diesel.voc.Ast
-import sourcecode.Name
+
+import diesel.i18n.DeclaringSourceName
 
 import scala.reflect.classTag
 
@@ -63,8 +64,8 @@ trait VocDsl extends Dsl {
   )(c: Concept): Seq[(DslConceptKey, DslConcept[Ast.Expr])] = {
     val key        = DslConceptKey(c.identifier)
     val sourceName = scope match {
-      case Some(value) => sourcecode.Name(s"${value}-${key}")
-      case None        => sourcecode.Name(s"${key}")
+      case Some(value) => DeclaringSourceName(s"${value}-${key}")
+      case None        => DeclaringSourceName(s"${key}")
     }
     if (c.parentIds.isEmpty) {
       Seq(key -> concept[Ast.Expr](classTag[Ast.Expr], sourceName))
@@ -94,10 +95,10 @@ trait VocDsl extends Dsl {
   var dedupCounter                       = 0
   private val dslPhrases: Seq[Phrase[_]] = vocabulary.factTypes.flatMap { ft =>
     ft.sentences.map { s =>
-      implicit val sourceName: Name = sourcecode.Name("voc" + dedupCounter)
+      implicit val sourceName = DeclaringSourceName("voc" + dedupCounter)
       dedupCounter += 1
-      val dslResultConcept          = VocDslUtils.useConcept(s.getSubject, ft.roles, dslConcepts)
-      val production                = VocDslUtils.toPhraseProduction(verbalizer, precedences)(
+      val dslResultConcept    = VocDslUtils.useConcept(s.getSubject, ft.roles, dslConcepts)
+      val production          = VocDslUtils.toPhraseProduction(verbalizer, precedences)(
         s,
         ft.roles,
         VerbalizationContext(article = DefiniteArticle),
@@ -112,9 +113,9 @@ trait VocDsl extends Dsl {
   }
 
   private val dslConceptInstances: Seq[Instance[Ast.Expr]] = vocabulary.conceptInstances.map { ci =>
-    implicit val sourceName: Name = sourcecode.Name("voc" + dedupCounter)
+    implicit val sourceName = DeclaringSourceName("voc" + dedupCounter)
     dedupCounter += 1
-    val dslResultConcept          = dslConcepts(DslConceptKey(ci.conceptId))
+    val dslResultConcept    = dslConcepts(DslConceptKey(ci.conceptId))
     instance(dslResultConcept)(ci.name) map { _ => Ast.Instance(ci.conceptId, ci.identifier) }
   }
 
@@ -137,13 +138,13 @@ trait VocDsl extends Dsl {
 
   // Temporary in order to have some variables available to do test
   private val dslSyntaxes_implicits: Seq[Syntax[Ast.Expr]] = vocabulary.concepts map { concept =>
-    implicit val sourceName: Name = sourcecode.Name("voc" + dedupCounter)
+    implicit val sourceName = DeclaringSourceName("voc" + dedupCounter)
     dedupCounter += 1
-    val dslResultConcept          = dslConcepts(DslConceptKey(concept.identifier))
-    val vc                        = VerbalizationContext(article = DemonstrativeArticle)
-    val text                      = verbalizer.verbalize(vc, ConceptVerbalizable(concept))
-    val words                     = text.trim().split(" ").map(t => SPStr(t))
-    val production                = if (words.length > 1) SPAndN(words.toSeq) else words(0)
+    val dslResultConcept    = dslConcepts(DslConceptKey(concept.identifier))
+    val vc                  = VerbalizationContext(article = DemonstrativeArticle)
+    val text                = verbalizer.verbalize(vc, ConceptVerbalizable(concept))
+    val words               = text.trim().split(" ").map(t => SPStr(t))
+    val production          = if (words.length > 1) SPAndN(words.toSeq) else words(0)
     syntax(dslResultConcept)(production map { case _ =>
       Ast.SyntaxExpr("this", concept.identifier, multiple = false, Seq())
     })

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,3 +1,3 @@
 object Dependencies {
-  lazy val dieselI18nVersion = "0.5.0"
+  lazy val dieselI18nVersion = "0.6.0"
 }

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -6,5 +6,5 @@ addSbtPlugin("de.heikoseeberger"  % "sbt-header"               % "5.9.0")
 addSbtPlugin("com.github.sbt"     % "sbt-ci-release"           % "1.5.11")
 
 addSbtPlugin(
-  "com.ibm.cloud.diesel" % "diesel-i18n-plugin" % "0.5.0"
+  "com.ibm.cloud.diesel" % "diesel-i18n-plugin" % "0.6.0"
 ) // Dependencies.dieselI18nVersion


### PR DESCRIPTION
Use macros to detect declaring field names from `diesel-i18n`, instead of `sourcecode`.