### PR TITLE
Marker post processor in JS facade

### DIFF
--- a/diesel/js/src/main/scala/diesel/facade/DieselFacade.scala
+++ b/diesel/js/src/main/scala/diesel/facade/DieselFacade.scala
@@ -54,7 +54,8 @@ class DieselParserFacade(
   }
 
   @JSExport
-  def parse(request: ParseRequest): DieselParseResult = DieselParseResult(doParse(request), markerPostProcessor)
+  def parse(request: ParseRequest): DieselParseResult =
+    DieselParseResult(doParse(request), markerPostProcessor)
 
   @JSExport
   def predict(request: PredictionRequest): DieselPredictResult = {
@@ -122,7 +123,10 @@ case class DieselStyle(private val styledRange: StyledRange) {
   val name: String = styledRange.style.name
 }
 
-class DieselParseResult(private val res: Either[String, GenericTree], private val markerPostProcessor: Option[MarkerPostProcessor]) {
+class DieselParseResult(
+  private val res: Either[String, GenericTree],
+  private val markerPostProcessor: Option[MarkerPostProcessor]
+) {
 
   @JSExport
   val success: Boolean = res.isRight
@@ -147,7 +151,8 @@ class DieselParseResult(private val res: Either[String, GenericTree], private va
 
 object DieselParseResult {
 
-  private def errorResult(reason: String): DieselParseResult = new DieselParseResult(Left(reason), None)
+  private def errorResult(reason: String): DieselParseResult =
+    new DieselParseResult(Left(reason), None)
 
   def apply(result: Result, markerPostProcessor: Option[MarkerPostProcessor]): DieselParseResult = {
     if (result.success) {

--- a/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
+++ b/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
@@ -85,11 +85,11 @@ class DieselFacadeTest extends FunSuite {
 
   test("facade should support marker post processing") {
     val facade = new DieselParserFacade(MyDsl, markerPostProcessor = Some(MyMarkerPostProcessor))
-    val res = facade.parse(DieselParsers.createParseRequest("1+2"))
+    val res    = facade.parse(DieselParsers.createParseRequest("1+2"))
     assert(res.success)
     assert(res.error.isEmpty)
     assertEquals(res.markers.length, 1)
-    val m0 = res.markers(0)
+    val m0     = res.markers(0)
     assertEquals(m0.offset, 0)
     assertEquals(m0.length, 3)
     assertEquals(m0.getMessage("en"), "yalla")


### PR DESCRIPTION
Allows to post-process the tree for more markers.