### PR TITLE
Fix dynamic phrases using SPAndN

### DIFF
--- a/diesel/shared/src/main/scala/diesel/Bnf.scala
+++ b/diesel/shared/src/main/scala/diesel/Bnf.scala
@@ -463,6 +463,16 @@ object Bnf {
             element,
             partial.feature
           )
+        case _                            =>
+          rule >> new Production(
+            Some(rule),
+            symbols,
+            { (context, args) =>
+              applicable.applyDynamic(context, args)
+            },
+            element,
+            partial.feature
+          )
       }
     }
 

--- a/diesel/shared/src/main/scala/diesel/Dsl.scala
+++ b/diesel/shared/src/main/scala/diesel/Dsl.scala
@@ -104,6 +104,7 @@ object Dsl {
   }
 
   trait Applicable[+T] {
+    // TODO Any => Product
     def applyDynamic(context: Context, args: Any): T
   }
 
@@ -654,8 +655,10 @@ object Dsl {
       with SPOrable[Seq[T]] {
 
     override def applyDynamic(context: Context, args: Any): Seq[T] = {
-      // the sequence comes in as a looong tuple
-      val vs = args.asInstanceOf[Product].productIterator.toSeq
+      val vs = args match {
+        case tuple: Product => tuple.productIterator.toSeq
+        case vs: Seq[Any]   => vs
+      }
       es.zip(vs).map { case (e, v) => e.applyDynamic(context, v) }
     }
   }

--- a/diesel/shared/src/test/scala/diesel/DslManyTokensTest.scala
+++ b/diesel/shared/src/test/scala/diesel/DslManyTokensTest.scala
@@ -1,0 +1,74 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diesel
+
+import diesel.Dsl.{Axiom, Concept, SPAndN, SPStr, Syntax}
+import munit.FunSuite
+
+class DslManyTokensTest extends FunSuite {
+
+  object MyDsl extends Dsl {
+
+    val string: Concept[String] = concept("\"[a-z]*\"".r, "") map ((_, t) => t.text)
+
+    val tokens = "this is a long phrase with many tokens before a string"
+      .split(" ")
+      .toSeq
+      .map(word => SPStr(word))
+
+    val sManyTokens: Syntax[String] = syntax(string)(
+      SPAndN(tokens :+ syntaxExprRef(string)) map {
+        case (_, ts) =>
+          ts.last.asInstanceOf[String]
+      }
+    )
+
+    val lessTokens = "this is a string"
+      .split(" ")
+      .toSeq
+      .map(word => SPStr(word))
+
+    val sLessTokens: Syntax[String] = syntax(string)(
+      SPAndN(lessTokens :+ syntaxExprRef(string)) map {
+        case (_, ts) =>
+          ts.last.asInstanceOf[String]
+      }
+    )
+
+    val a: Axiom[String] = axiom(string)
+
+  }
+
+  test("many tokens") {
+    AstHelpers.assertAst(MyDsl)(
+      "this is a long phrase with many tokens before a string \"hello\""
+    ) { tree =>
+      assertEquals(tree.markers, Seq())
+      assertEquals(tree.root.value, "\"hello\"")
+    }
+  }
+
+  test("less tokens") {
+    AstHelpers.assertAst(MyDsl)(
+      "this is a string \"hello\""
+    ) { tree =>
+      assertEquals(tree.markers, Seq())
+      assertEquals(tree.root.value, "\"hello\"")
+    }
+  }
+
+}


### PR DESCRIPTION
When there are more then 8 tokens parsed for a SPAndN, we get a `scala.MatchError`.
