### PR TITLE
Completion "lookback" for finding prefixes

### DIFF
--- a/diesel-samples/shared/src/main/scala/diesel/samples/jsmodeldsl/JsModelDsl.scala
+++ b/diesel-samples/shared/src/main/scala/diesel/samples/jsmodeldsl/JsModelDsl.scala
@@ -153,6 +153,7 @@ case object JsModelDsl extends Dsl with Identifiers with Comments with DynamicLe
   def completionConfiguration: CompletionConfiguration = {
     val config = new CompletionConfiguration()
     config.setFilter(MyFilter)
+    config.setLookback(SimpleCompletionLookback(":{}[],"))
     config
   }
 

--- a/diesel-samples/shared/src/test/scala/diesel/samples/feel/FeelPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/feel/FeelPredictionTest.scala
@@ -67,12 +67,4 @@ class FeelPredictionTest extends FunSuite {
     )
   }
 
-  test("tru") {
-    assertPredictions(
-      "tru",
-      3,
-      ALL
-    )
-  }
-
 }

--- a/diesel-samples/shared/src/test/scala/diesel/samples/feel/FeelPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/feel/FeelPredictionTest.scala
@@ -30,38 +30,48 @@ class FeelPredictionTest extends FunSuite {
     val config      = new CompletionConfiguration()
     val feel        = new Feel
     val predictions = predict(feel, text, offset, Some(config))
-    assert(predictions.map(_.text) == expectedPredictions)
+    assertEquals(predictions.map(_.text), expectedPredictions)
   }
+
+  private def ALL = List(
+    "-",
+    "not (",
+    "(",
+    "[",
+    "function (",
+    "{",
+    "for",
+    "if",
+    "-",
+    "[a-z]+",
+    "some",
+    "every",
+    "null",
+    ">=",
+    "<=",
+    ">",
+    "<",
+    "[",
+    "true",
+    "false",
+    "0",
+    "\"\"",
+    "@"
+  )
 
   test("empty text") {
     assertPredictions(
       "",
       0,
-      List(
-        "-",
-        "not (",
-        "(",
-        "[",
-        "function (",
-        "{",
-        "for",
-        "if",
-        "-",
-        "[a-z]+",
-        "some",
-        "every",
-        "null",
-        ">=",
-        "<=",
-        ">",
-        "<",
-        "[",
-        "true",
-        "false",
-        "0",
-        "\"\"",
-        "@"
-      )
+      ALL
+    )
+  }
+
+  test("tru") {
+    assertPredictions(
+      "tru",
+      3,
+      ALL
     )
   }
 

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/BmdDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/BmdDslPredictionTest.scala
@@ -61,16 +61,16 @@ class BmdDslPredictionTest extends FunSuite {
 
   test("start") {
     assertPredictions(
-      "start",
-      5,
+      "start ",
+      6,
       Seq("with")
     )
   }
 
   test("start with") {
     assertPredictions(
-      "start with",
-      10,
+      "start with ",
+      11,
       Seq("text", "numeric", "a")
     )
   }
@@ -81,7 +81,7 @@ class BmdDslPredictionTest extends FunSuite {
         |a Foo is a concept.
         |a Bar is a concept.
         |""".stripMargin,
-      12,
+      13,
       // TODO should be?
 //      Seq("Foo", "Bar")
       Seq("Bar")
@@ -101,7 +101,7 @@ class BmdDslPredictionTest extends FunSuite {
 
   test("is a concept") {
     assertPredictions(
-      "a shopping cart",
+      "a shopping cart ",
       16,
       Seq("has", "can be", "is a", "can be one of", ".")
     )
@@ -112,7 +112,7 @@ class BmdDslPredictionTest extends FunSuite {
       """a Foo is a concept.
         |a Foo has a bar (text)
         |""".stripMargin,
-      19 + 22 + 1,
+      19 + 23 + 1,
       Seq("[ optional ]", ".")
     )
   }

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -39,7 +39,7 @@ class JsModelDslPredictionTest extends FunSuite {
     offset: Int,
     expectedPredictions: Seq[String]
   ): Unit = {
-    val proposals = predict(JsModelDsl, text, offset, Some(JsModelDsl.completionConfiguration))
+    val proposals = predict(JsModelDsl, text, offset, None)
     assertEquals(proposals.map(_.text), expectedPredictions)
   }
 

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -82,7 +82,7 @@ class JsModelDslPredictionTest extends FunSuite {
     )
   }
 
-  test("root".only) {
+  test("root") {
     assertPredictions(
       "root",
       4,

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -86,7 +86,7 @@ class JsModelDslPredictionTest extends FunSuite {
     assertPredictions(
       "root",
       4,
-      Seq(":")
+      Seq("root :")
     )
   }
 
@@ -109,10 +109,18 @@ class JsModelDslPredictionTest extends FunSuite {
     )
   }
 
-  test("array or class or domain") {
+  test("array or class or domain 1") {
     assertPredictions(
       "root: number",
       12,
+      Seq("string", "boolean", "number")
+    )
+  }
+
+  test("array or class or domain 2") {
+    assertPredictions(
+      "root: number ",
+      13,
       Seq("[]", "class", "domain")
     )
   }
@@ -141,7 +149,7 @@ class JsModelDslPredictionTest extends FunSuite {
         |class MyClass {
         |  foo
         |}""".stripMargin,
-      35,
+      36,
       Seq("?", ":")
     )
   }

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -28,12 +28,19 @@ class JsModelDslPredictionTest extends FunSuite {
     expectedReplace: Option[Seq[Option[(Int, Int)]]] = None
   ): Unit = {
     val proposals = predict(JsModelDsl, text, offset, Some(JsModelDsl.completionConfiguration))
-    assert(
-      proposals.map(_.text) == expectedPredictions
-    )
+    assertEquals(proposals.map(_.text), expectedPredictions)
     expectedReplace.foreach { expectedReplace =>
       assertEquals(proposals.map(_.replace), expectedReplace)
     }
+  }
+
+  private def assertPredictionsNoCompletionConfig(
+    text: String,
+    offset: Int,
+    expectedPredictions: Seq[String]
+  ): Unit = {
+    val proposals = predict(JsModelDsl, text, offset, Some(JsModelDsl.completionConfiguration))
+    assertEquals(proposals.map(_.text), expectedPredictions)
   }
 
   test("empty") {
@@ -46,6 +53,14 @@ class JsModelDslPredictionTest extends FunSuite {
 
   test("root with prefix") {
     assertPredictions(
+      "ro",
+      2,
+      Seq("root :")
+    )
+  }
+
+  test("root with prefix no config") {
+    assertPredictionsNoCompletionConfig(
       "ro",
       2,
       Seq("root :")

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -44,6 +44,14 @@ class JsModelDslPredictionTest extends FunSuite {
     )
   }
 
+  test("root with prefix") {
+    assertPredictions(
+      "ro",
+      2,
+      Seq("root :")
+    )
+  }
+
   test("root") {
     assertPredictions(
       "root",

--- a/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
+++ b/diesel-samples/shared/src/test/scala/diesel/samples/jsmodeldsl/JsModelDslPredictionTest.scala
@@ -34,15 +34,6 @@ class JsModelDslPredictionTest extends FunSuite {
     }
   }
 
-  private def assertPredictionsNoCompletionConfig(
-    text: String,
-    offset: Int,
-    expectedPredictions: Seq[String]
-  ): Unit = {
-    val proposals = predict(JsModelDsl, text, offset, None)
-    assertEquals(proposals.map(_.text), expectedPredictions)
-  }
-
   test("empty") {
     assertPredictions(
       "",
@@ -59,15 +50,39 @@ class JsModelDslPredictionTest extends FunSuite {
     )
   }
 
-  test("root with prefix no config") {
-    assertPredictionsNoCompletionConfig(
-      "ro",
+  test("root with prefix 2") {
+    assertPredictions(
+      "root : number",
       2,
       Seq("root :")
     )
   }
 
-  test("root") {
+  test("root with prefix 3") {
+    assertPredictions(
+      "root : ",
+      2,
+      Seq("root :")
+    )
+  }
+
+  test("root with prefix 4") {
+    assertPredictions(
+      "roo",
+      2,
+      Seq("root :")
+    )
+  }
+
+  test("root with prefix 5") {
+    assertPredictions(
+      "ro :",
+      2,
+      Seq("root :")
+    )
+  }
+
+  test("root".only) {
     assertPredictions(
       "root",
       4,

--- a/diesel/js/src/main/scala/diesel/facade/DieselFacade.scala
+++ b/diesel/js/src/main/scala/diesel/facade/DieselFacade.scala
@@ -48,7 +48,7 @@ class DieselParserFacade(
 
   @JSExport
   def predict(request: PredictRequest): DieselPredictResult = {
-    DieselPredictResult(doParse(request), request.offset, config, userDataProvider)
+    DieselPredictResult(doParse(request), request.text, request.offset, config, userDataProvider)
   }
 
   // TODO borrowed from AstHelper
@@ -180,6 +180,7 @@ class DieselCompletionProposal(private val proposal: CompletionProposal) {
     .map(new Replace(_))
     .orUndefined
 
+  override def toString = s"DieselCompletionProposal($text, $replace)"
 }
 
 case class DieselPredictResult(private val res: Either[String, Seq[CompletionProposal]]) {
@@ -205,6 +206,7 @@ object DieselPredictResult {
 
   def apply(
     result: Result,
+    text: String,
     offset: Int,
     config: Option[CompletionConfiguration],
     userDataProvider: Option[UserDataProvider]
@@ -214,6 +216,7 @@ object DieselPredictResult {
       if (navigator.hasNext) {
         val proposals = new CompletionProcessor(
           result,
+          text,
           config,
           userDataProvider
         ).computeCompletionProposal(offset).distinctBy(

--- a/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
+++ b/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
@@ -71,14 +71,17 @@ class DieselFacadeTest extends FunSuite {
 
   test("facade should predict calc dsl") {
     val facade = new DieselParserFacade(MyDsl)
-    val res    = facade.predict(createPredictRequest("1 + ", 3))
+    val res    = facade.predict(createPredictRequest("1 + ", 4))
     assert(res.success)
     assert(res.error.isEmpty)
+
+    println(res.proposals)
+
     assertEquals(res.proposals.length, 5)
-    val p0     = res.proposals(0)
+    val p0 = res.proposals(0)
     assertEquals(p0.text, "0")
     assert(p0.replace.isEmpty)
-    val p1     = res.proposals(1)
+    val p1 = res.proposals(1)
     assertEquals(p1.text, "pi")
     assert(p1.replace.isEmpty)
   }

--- a/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
+++ b/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
@@ -74,14 +74,11 @@ class DieselFacadeTest extends FunSuite {
     val res    = facade.predict(createPredictRequest("1 + ", 4))
     assert(res.success)
     assert(res.error.isEmpty)
-
-    println(res.proposals)
-
     assertEquals(res.proposals.length, 5)
-    val p0 = res.proposals(0)
+    val p0     = res.proposals(0)
     assertEquals(p0.text, "0")
     assert(p0.replace.isEmpty)
-    val p1 = res.proposals(1)
+    val p1     = res.proposals(1)
     assertEquals(p1.text, "pi")
     assert(p1.replace.isEmpty)
   }

--- a/diesel/shared/src/main/scala/diesel/AstHelpers.scala
+++ b/diesel/shared/src/main/scala/diesel/AstHelpers.scala
@@ -57,6 +57,7 @@ object AstHelpers {
     val a              = getBnfAxiomOrThrow(bnf, axiom)
     val res            = new CompletionProcessor(
       parser.parse(new Lexer.Input(text), a),
+      text,
       config,
       userDataProvider
     ).computeCompletionProposal(offset)

--- a/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
+++ b/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
@@ -17,6 +17,7 @@
 package diesel
 
 import diesel.Bnf.{DslElement, Token}
+import diesel.CompletionProcessor.findPrefix
 
 import scala.collection.mutable
 
@@ -45,39 +46,92 @@ trait CompletionProvider {
   ): Seq[CompletionProposal]
 }
 
+trait CompletionLookback {
+  def isCompletionDelimiter(c: Char): Boolean
+}
+
+object DefaultCompletionLookback extends CompletionLookback {
+  override def isCompletionDelimiter(c: Char): Boolean = c.isWhitespace
+}
+
+case class SimpleCompletionLookback(chars: String) extends CompletionLookback {
+  override def isCompletionDelimiter(c: Char): Boolean =
+    DefaultCompletionLookback.isCompletionDelimiter(c) || chars.contains(c)
+}
+
 class CompletionConfiguration {
 
   private val providers: mutable.Map[DslElement, CompletionProvider] = mutable.Map()
-  var filter: Option[CompletionFilter]                               = None
+  private var filter: Option[CompletionFilter]                       = None
+  private var lookback: Option[CompletionLookback]                   = None
 
-  def setProvider[T](dslElement: DslElement, p: CompletionProvider): Unit = {
+  def setProvider(dslElement: DslElement, p: CompletionProvider): Unit = {
     providers(dslElement) = p
   }
 
-  def getProvider[T](dslElement: DslElement): Option[CompletionProvider] = providers.get(dslElement)
+  def getProvider(dslElement: DslElement): Option[CompletionProvider] = providers.get(dslElement)
 
   def setFilter(f: CompletionFilter): Unit = {
     filter = Some(f)
+  }
+
+  def getFilter: Option[CompletionFilter] = filter
+
+  def getLookback: Option[CompletionLookback] = lookback
+
+  def setLookback(l: CompletionLookback): Unit = {
+    lookback = Some(l)
+  }
+
+}
+
+object CompletionProcessor {
+  def findPrefix(text: String, offset: Int, lookback: CompletionLookback): String = {
+    if (text.isEmpty || offset == 0) {
+      ""
+    } else {
+      val leftOffset = offset - 1
+      val c          = text.charAt(leftOffset)
+      if (lookback.isCompletionDelimiter(c)) {
+        ""
+      } else {
+        findPrefix(text, leftOffset, lookback) + c
+      }
+    }
   }
 
 }
 
 class CompletionProcessor(
   val result: Result,
+  val text: String,
   val config: Option[CompletionConfiguration] = None,
   val userDataProvider: Option[UserDataProvider] = None
 ) {
 
   def computeCompletionProposal(offset: Int): Seq[CompletionProposal] = {
+
+    val lookback = config
+      .flatMap(_.getLookback)
+      .getOrElse(DefaultCompletionLookback)
+
+    // adjust offset (prefix)
+    val prefix = findPrefix(text, offset, lookback)
+
     val navigator = new Navigator(result, Seq(), userDataProvider)
     navigator.toIterator
       .toSeq
       .foldLeft(Seq.empty[CompletionProposal]) { case (acc, tree) =>
         var node: Option[GenericNode]          = None
         var defaultReplace: Option[(Int, Int)] = None
-        val treeProposals                      = result.chartAndPrefixAtOffset(offset)
-          .map({ case (chart, prefix) =>
-            defaultReplace = prefix.map(p => (offset - p.length, p.length))
+        val treeProposals                      = result.chartAtOffset(offset - prefix.length)
+          .map { chart =>
+            defaultReplace =
+              if (prefix.isEmpty) {
+                None
+              } else {
+                Some((offset - prefix.length, prefix.length))
+              }
             node = tree.root.findNodeAtIndex(chart.index)
             chart.notCompletedStates
               .filterNot(_.kind(result) == StateKind.ErrorRecovery)
@@ -95,7 +149,7 @@ class CompletionProcessor(
                       CompletionProposal(
                         element,
                         text,
-                        prefix.map(p => (offset - p.length, p.length))
+                        defaultReplace
                       )
                     )
                     .toSeq
@@ -107,10 +161,10 @@ class CompletionProcessor(
                   .getOrElse(defaultProvider)
                   .getProposals(element, tree, offset, node)
               })
-          })
+          }
           .getOrElse(Seq.empty)
         acc ++ config
-          .flatMap(c => c.filter)
+          .flatMap(c => c.getFilter)
           .map(f => f.filterProposals(tree, offset, node, treeProposals))
           .getOrElse(treeProposals)
           .map(proposal => proposal.copy(replace = proposal.replace.orElse(defaultReplace)))

--- a/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
+++ b/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
@@ -54,7 +54,11 @@ object DefaultCompletionLookback extends CompletionLookback {
   override def isCompletionDelimiter(c: Char): Boolean = c.isWhitespace
 }
 
-case class SimpleCompletionLookback(chars: String) extends CompletionLookback {
+object SimpleCompletionLookback {
+  def apply(chars: String): SimpleCompletionLookback = SimpleCompletionLookback(chars.toSet)
+}
+
+case class SimpleCompletionLookback(chars: Set[Char]) extends CompletionLookback {
   override def isCompletionDelimiter(c: Char): Boolean =
     DefaultCompletionLookback.isCompletionDelimiter(c) || chars.contains(c)
 }

--- a/diesel/shared/src/main/scala/diesel/EarleyState.scala
+++ b/diesel/shared/src/main/scala/diesel/EarleyState.scala
@@ -291,30 +291,12 @@ class Result(val axiom: Bnf.Axiom) {
     chart
   }
 
-  private def getTokenPrefix(offset: Int, token: Token): String = {
-    val diff = token.offset + token.length - offset
-    token.text.dropRight(diff)
-  }
-
-  private[diesel] def chartAndPrefixAtOffset(offset: Int): Option[(Chart, Option[String])] = {
-    val c = charts.find { chart =>
+  private[diesel] def chartAtOffset(offset: Int): Option[Chart] = {
+    charts.find { chart =>
       chart.isAtOffset(offset)
     }.orElse(charts.find { chart =>
       chart.isAfterOffset(offset)
     })
-
-    def tokenEndsAt(offset: Int) = {
-      t: Token => t.offset + t.length == offset
-    }
-
-    val prefix = errorTokens
-      .find(tokenEndsAt(offset))
-      .orElse(c.flatMap(_.token))
-      .map(getTokenPrefix(offset, _))
-      .filter(_.nonEmpty)
-//      .map(_.text)
-
-    c.map((_, prefix))
   }
 
   private[diesel] def chartAt(index: Int) = {

--- a/diesel/shared/src/test/scala/diesel/CalcTest.scala
+++ b/diesel/shared/src/test/scala/diesel/CalcTest.scala
@@ -143,17 +143,22 @@ class CalcTest extends DslTestFunSuite {
   }
 
   test("predict") {
-    val res1 = predict(MyDsl, "", 0)
+    val config = new CompletionConfiguration()
+    config.setLookback(SimpleCompletionLookback("()+*-/"))
+    val res1   = predict(MyDsl, "", 0, Some(config))
 //    println(res1)
-    assert(res1.containsSlice(Seq(
-      CompletionProposal(Some(DslValue(MyDsl.number)), "0"),
-      CompletionProposal(Some(DslInstance(MyDsl.pi)), "pi"),
-      CompletionProposal(Some(DslSyntax(MyDsl.cos)), "cos ("),
-      CompletionProposal(Some(DslSyntax(MyDsl.subExpr)), "("),
-      CompletionProposal(Some(DslSyntax(MyDsl.sumExpr)), "sum (")
-    )))
+    assertEquals(
+      res1,
+      Seq(
+        CompletionProposal(Some(DslValue(MyDsl.number)), "0"),
+        CompletionProposal(Some(DslInstance(MyDsl.pi)), "pi"),
+        CompletionProposal(Some(DslSyntax(MyDsl.cos)), "cos ("),
+        CompletionProposal(Some(DslSyntax(MyDsl.subExpr)), "("),
+        CompletionProposal(Some(DslSyntax(MyDsl.sumExpr)), "sum (")
+      )
+    )
 
-    val res2 = predict(MyDsl, "10 ", 3)
+    val res2 = predict(MyDsl, "10 ", 3, Some(config))
 //    println(res2)
     assert(res2.containsSlice(Seq(
       CompletionProposal(Some(DslSyntax(MyDsl.add)), "+"),

--- a/diesel/shared/src/test/scala/diesel/CompletionProcessorTest.scala
+++ b/diesel/shared/src/test/scala/diesel/CompletionProcessorTest.scala
@@ -1,0 +1,48 @@
+package diesel
+
+import munit.FunSuite
+
+class CompletionProcessorTest extends FunSuite {
+
+  private def doCheck(text: String, offset: Int, expected: String): Unit = {
+    val prefix = CompletionProcessor.findPrefix(text, offset, DefaultCompletionLookback)
+    assertEquals(prefix, expected)
+  }
+
+  test("empty string") {
+    doCheck("", 0, "")
+  }
+
+  test("whitespaces") {
+    doCheck("   ", 1, "")
+  }
+
+  test("inside id 0") {
+    doCheck("foo bar", 0, "")
+  }
+
+  test("inside id 1") {
+    doCheck("foo bar", 1, "f")
+  }
+
+  test("inside id 3") {
+    doCheck("foo bar", 3, "foo")
+  }
+
+  test("inside id 4") {
+    doCheck("foo bar", 4, "")
+  }
+
+  test("inside id 5") {
+    doCheck("foo bar", 5, "b")
+  }
+
+  test("inside id 7") {
+    doCheck("foo bar", 7, "bar")
+  }
+
+  test("eos") {
+    doCheck("ro", 2, "ro")
+  }
+
+}

--- a/diesel/shared/src/test/scala/diesel/CompletionProcessorTest.scala
+++ b/diesel/shared/src/test/scala/diesel/CompletionProcessorTest.scala
@@ -1,3 +1,19 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 package diesel
 
 import munit.FunSuite

--- a/diesel/shared/src/test/scala/diesel/PredictWithPrefixTest.scala
+++ b/diesel/shared/src/test/scala/diesel/PredictWithPrefixTest.scala
@@ -111,6 +111,14 @@ class PredictWithPrefixTest extends FunSuite {
     )
   }
 
+  test("go") {
+    assertPredictions(
+      "go",
+      2,
+      expectedAll
+    )
+  }
+
   test("good") {
     assertPredictions(
       "good ",
@@ -130,6 +138,14 @@ class PredictWithPrefixTest extends FunSuite {
   test("good 3") {
     assertPredictions(
       "good xxx",
+      7,
+      Seq("job", "day")
+    )
+  }
+
+  test("good 4") {
+    assertPredictions(
+      "good jo",
       7,
       Seq("job", "day")
     )

--- a/diesel/shared/src/test/scala/diesel/PredictWithPrefixTest.scala
+++ b/diesel/shared/src/test/scala/diesel/PredictWithPrefixTest.scala
@@ -183,7 +183,10 @@ class PredictWithPrefixTest extends FunSuite {
 
   test("replace 4") {
     val proposals = AstHelpers.predict(MyDsl, "foo", 3)
-    assertEquals(proposals.size, 0)
+    assertEquals(proposals.size, 5)
+    proposals.foreach(p => {
+      assertEquals(p.replace, Some((0, 3)))
+    })
   }
 
   test("replace 5") {
@@ -204,6 +207,9 @@ class PredictWithPrefixTest extends FunSuite {
 
   test("replace 7") {
     val proposals = AstHelpers.predict(MyDsl, "good job", 8)
-    assertEquals(proposals.size, 0)
+    assertEquals(proposals.size, 2)
+    proposals.foreach(p => {
+      assertEquals(p.replace.get, (5, 3))
+    })
   }
 }

--- a/diesel/shared/src/test/scala/diesel/PredictionAndSpacesTest.scala
+++ b/diesel/shared/src/test/scala/diesel/PredictionAndSpacesTest.scala
@@ -44,7 +44,9 @@ class PredictionAndSpacesTest extends FunSuite {
   private val expectedPredictions = Seq("foo", "bar")
 
   private def assertPredictions(text: String, offset: Int, expected: Seq[String]) = {
-    val proposals = predict(MyDsl, text, offset, None)
+    val config    = new CompletionConfiguration()
+    config.setLookback(SimpleCompletionLookback("{}"))
+    val proposals = predict(MyDsl, text, offset, Some(config))
     assertEquals(proposals.map(_.text), expected)
   }
 


### PR DESCRIPTION
Adds `CompletionLookback` to the `CompletionConguration`, so that users may tweak how prefixes are found when triggering completion at a given offset. 
Trying to do this at the fwk level is impossible, so we prefer to provide users a way to handle this as they see fit. 

Fixes #26 