### PR TITLE
Per-request contexts

### DIFF
--- a/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
+++ b/diesel/js/src/test/scala/diesel/facade/DieselFacadeTest.scala
@@ -96,12 +96,16 @@ class DieselFacadeTest extends FunSuite {
   }
 
   test("facade should support marker post processing") {
-    val facade = new DieselParserFacade(MyDsl, markerPostProcessor = Some(MyMarkerPostProcessor))
-    val res    = facade.parse(createParseRequest("1+2"))
+    val parseContextFactory = (pr: ParseRequest) =>
+      ParseContext(markerPostProcessor =
+        Some(MyMarkerPostProcessor)
+      )
+    val facade              = new DieselParserFacade(MyDsl, parseContextFactory = Some(parseContextFactory))
+    val res                 = facade.parse(createParseRequest("1+2"))
     assert(res.success)
     assert(res.error.isEmpty)
     assertEquals(res.markers.length, 1)
-    val m0     = res.markers(0)
+    val m0                  = res.markers(0)
     assertEquals(m0.offset, 0)
     assertEquals(m0.length, 3)
     assertEquals(m0.getMessage("en"), "yalla")

--- a/facade/samples-bundle/src/main/scala/diesel/samples/DieselSamples.scala
+++ b/facade/samples-bundle/src/main/scala/diesel/samples/DieselSamples.scala
@@ -22,13 +22,21 @@ import diesel.samples.jsmodeldsl.BmdDsl
 import diesel.samples.sfeel.SFeel
 
 import scala.scalajs.js.annotation.{JSExport, JSExportTopLevel}
+import diesel.facade.PredictRequest
+import diesel.facade.PredictContext
 
 @JSExportTopLevel("DieselSamples")
 object DieselSamples {
 
   @JSExport
-  def createBmdParser(): DieselParserFacade =
-    new DieselParserFacade(BmdDsl, Some(BmdDsl.completionConfiguration))
+  def createBmdParser(): DieselParserFacade = {
+    val predictContextFactory = (r: PredictRequest) =>
+      PredictContext(config =
+        Some(BmdDsl.completionConfiguration)
+      )
+
+    new DieselParserFacade(BmdDsl, predictContextFactory = Some(predictContextFactory))
+  }
 
   @JSExport
   def createGlslParser(): DieselParserFacade = new DieselParserFacade(Glsl)


### PR DESCRIPTION
This allows facade users to change contextual objects (UserData, Navigator, etc) without recreating the parser.