### PR TITLE
Handling of epsilon-states in chart when parsing

### DIFF
--- a/diesel/shared/src/main/scala/diesel/Bnf.scala
+++ b/diesel/shared/src/main/scala/diesel/Bnf.scala
@@ -1577,4 +1577,6 @@ case class Bnf(lexer: Lexer, rules: Seq[NonTerminal]) {
       }
     }
   }
+
+  val emptyRules: Set[Bnf.NonTerminal] = BnfEmptyRules(this).emptyRules
 }

--- a/diesel/shared/src/main/scala/diesel/BnfEmptyRules.scala
+++ b/diesel/shared/src/main/scala/diesel/BnfEmptyRules.scala
@@ -1,0 +1,68 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diesel
+
+import scala.annotation.tailrec
+
+private[diesel] case class BnfEmptyRules(bnf: Bnf) {
+
+  private def isEmpty(production: Bnf.Production, emptyRules: Set[Bnf.NonTerminal]): Boolean =
+    if (production.length == 0)
+      true
+    else {
+      production.symbols.forall(s =>
+        !s.isToken && (s.isRule && emptyRules.contains(s.asInstanceOf[Bnf.NonTerminal]))
+      )
+    }
+
+  @tailrec
+  private def computeEmptyRules(
+    rule: Bnf.NonTerminal,
+    emptyRules: Set[Bnf.NonTerminal]
+  ): Set[Bnf.NonTerminal] =
+    if (emptyRules.contains(rule))
+      emptyRules
+    else {
+      rule match {
+        case Bnf.Rule(_, productions) =>
+          if (productions.exists(isEmpty(_, emptyRules)))
+            emptyRules ++ Set(rule)
+          else
+            emptyRules
+
+        case Bnf.Axiom(rule) => computeEmptyRules(rule, emptyRules)
+      }
+    }
+
+  val emptyRules: Set[Bnf.NonTerminal] = {
+    var emptyRules: Set[Bnf.NonTerminal] = Set()
+    var cont                             = false
+    do {
+      cont = false
+      var i = bnf.rules
+      while (i.nonEmpty) {
+        val newEmptyRules = computeEmptyRules(i.head, emptyRules)
+        if (newEmptyRules.size > emptyRules.size) {
+          cont = true
+          emptyRules = newEmptyRules
+        }
+        i = i.tail
+      }
+    } while (cont)
+    emptyRules
+  }
+}

--- a/diesel/shared/src/test/scala/diesel/EpsilonTest.scala
+++ b/diesel/shared/src/test/scala/diesel/EpsilonTest.scala
@@ -39,6 +39,23 @@ class EpsilonTest extends FunSuite {
     val a: Axiom[String] = axiom(s)
   }
 
+  test("BNF") {
+    def dsl = MyDsl
+    def bnf = Bnf(dsl)
+    assertEquals(
+      bnf.emptyRules.map(r => r.name),
+      Set(
+        "a[_,_,_,_,_]",
+        "syntax[_,_,_,_,_].b",
+        "syntax[_,_,_,_,_].b.map.1",
+        "syntax[_,_,_,_,_].s.map.0",
+        "syntax[_,_,_,_,_].b.map.1.opt.2",
+        "syntax[_,_,_,_,_].s"
+      )
+    )
+    // "syntax[_,_,_,_,_].b.map.1.opt.2.item" -> "b"
+  }
+
   test("none") {
     AstHelpers.selectAst(MyDsl)("") { tree =>
       AstHelpers.assertNoMarkers(tree)

--- a/diesel/shared/src/test/scala/diesel/EpsilonTest.scala
+++ b/diesel/shared/src/test/scala/diesel/EpsilonTest.scala
@@ -1,0 +1,85 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diesel
+
+import diesel.Dsl.{Axiom, Syntax}
+import diesel.Errors.Ambiguous
+import munit.FunSuite
+
+class EpsilonTest extends FunSuite {
+
+  object MyDsl extends Dsl {
+
+    val b: Syntax[String] = syntax("b".? map {
+      case (_, b) => b match {
+          case Some(value) => value.text
+          case None        => ""
+        }
+    })
+
+    val s: Syntax[String] = syntax(b ~ b ~ b ~ b ~ b map {
+      case (_, (b1, b2, b3, b4, b5)) =>
+        b1 + b2 + b3 + b4 + b5
+    })
+
+    val a: Axiom[String] = axiom(s)
+  }
+
+  test("none") {
+    AstHelpers.selectAst(MyDsl)("") { tree =>
+      AstHelpers.assertNoMarkers(tree)
+      assertEquals(tree.value, "")
+    }
+  }
+
+  test("one") {
+    AstHelpers.selectAst(MyDsl)("b") { tree =>
+      assertEquals(tree.markers.length, 1)
+      assertEquals(tree.markers.head, Ambiguous.apply(0, 1))
+      assertEquals(tree.value, "b")
+    }
+  }
+
+  test("two") {
+    AstHelpers.selectAst(MyDsl)("bb") { tree =>
+      assertEquals(tree.markers.length, 1)
+      assertEquals(tree.markers.head, Ambiguous.apply(0, 2))
+      assertEquals(tree.value, "bb")
+    }
+  }
+
+  test("three") {
+    AstHelpers.selectAst(MyDsl)("bbb") { tree =>
+      assertEquals(tree.markers.length, 1)
+      assertEquals(tree.markers.head, Ambiguous.apply(0, 3))
+      assertEquals(tree.value, "bbb")
+    }
+  }
+
+  test("four") {
+    AstHelpers.selectAst(MyDsl)("bbbb") { tree =>
+      assertEquals(tree.value, "bbbb")
+    }
+  }
+
+  test("five") {
+    AstHelpers.selectAst(MyDsl)("bbbbb") { tree =>
+      AstHelpers.assertNoMarkers(tree)
+      assertEquals(tree.value, "bbbbb")
+    }
+  }
+}


### PR DESCRIPTION
Fix handling of epsilon states in chart when parsing

[Earley cannot handle epsilon-states already contained in chart](https://stackoverflow.com/questions/35524183/earley-cannot-handle-epsilon-states-already-contained-in-chart)