### PR TITLE
Improve compute filter

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -115,7 +115,7 @@ lazy val diesel = crossProject(JSPlatform, JVMPlatform)
     libraryDependencies ++= Seq(
       "com.ibm.cloud.diesel" %%% "diesel-i18n"   % Dependencies.dieselI18nVersion,
       scalaOrganization.value  % "scala-reflect" % scalaVersion.value,
-      "org.scalameta"        %%% "munit"         % "1.0.0-M7" % Test
+      "org.scalameta"        %%% "munit"         % "1.0.0-RC1" % Test
     )
   )
   .settings(sharedSettings_test)

--- a/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
+++ b/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
@@ -171,12 +171,7 @@ case class PredictionState(private[diesel] val state: State, private val result:
     chart: Chart,
     dejaVue: Set[State]
   ): Seq[PredictionState] = {
-    val matched = chart.notCompletedStates.filter(candidate =>
-      candidate.production.symbols.apply(candidate.dot) match {
-        case rule: Bnf.NonTerminal => state.rule == rule
-        case _                     => false
-      }
-    )
+    val matched = chart.activeRules(state.rule)
       .filterNot(dejaVue.contains)
       .map(s => PredictionState(s, result))
     matched.flatMap(s =>

--- a/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
+++ b/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
@@ -283,7 +283,9 @@ class CompletionProcessor(
     }
 
     def initCompute(predictionState: PredictionState): Seq[PredictionState] = {
-      config.flatMap(_.getComputeFilter).toSeq.flatMap(_.initVisit(predictionState))
+      config.flatMap(_.getComputeFilter).map(_.initVisit(predictionState)).getOrElse(Seq(
+        predictionState
+      ))
     }
 
     def beginCompute(predictionState: PredictionState): Boolean = {

--- a/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
+++ b/diesel/shared/src/main/scala/diesel/CompletionProcessor.scala
@@ -91,17 +91,6 @@ class CompletionConfiguration {
     this.computeFilter
 }
 
-trait PredictionNode {
-
-  def element: Option[DslElement]
-
-  def predecessorNodes: Seq[PredictionNode]
-
-  def subElementsBefore: Seq[DslElement]
-
-  def subElementAfter: Option[DslElement]
-}
-
 // <...> the brother of 'joe' 's sister is . 'someone' <...>
 // "toto" is . null
 
@@ -130,8 +119,6 @@ object PredictionState {
 
 case class PredictionState(private[diesel] val state: State, private val result: Result) {
 
-  def toPredictionNode: PredictionNode = ???
-
   def isAxiom: Boolean =
     state.production.element match {
       case Some(element) => element match {
@@ -141,12 +128,17 @@ case class PredictionState(private[diesel] val state: State, private val result:
       case None          => false
     }
 
+  /** If there is a non-terminal right to the dot, it returns the number of non-terminals to the
+    * left of the dot.
+    */
   val subIndex: Option[Int] =
     if (state.production.symbols(state.dot).isToken)
       None
     else
       Some(state.production.symbols.take(state.dot + 1).count(_.isRule) - 1)
 
+  /** It returns the first 'sub index' left to the dot, if it exists.
+    */
   val leftSubIndex: Option[Int] =
     if (state.dot == 0)
       None
@@ -241,6 +233,8 @@ case class PredictionState(private[diesel] val state: State, private val result:
       }
     } else Seq.empty
 
+  /** Returns all the text under the non-terminal at 'sub index'
+    */
   def textsAt(subIndex: Int): Seq[String] = textsAt(state, toIndex(subIndex))
 
   private def textsAt(state: State, index: Int): Seq[String] =

--- a/diesel/shared/src/test/scala/diesel/PredictionPropagationTest.scala
+++ b/diesel/shared/src/test/scala/diesel/PredictionPropagationTest.scala
@@ -265,14 +265,20 @@ class PredictionPropagationTest extends FunSuite {
     }
 
     override def initVisit(predictionState: PredictionState): Seq[PredictionState] = {
-      val up = predictionState.element match {
-        case Some(DslSyntax(syntax)) if syntax.userData.contains(MyDsl.literalListId) => true
-        case _                                                                        => false
+      def isLiteralList(element: DslElement): Boolean = element match {
+        case DslSyntax(syntax) => syntax.userData.contains(MyDsl.literalListId)
+        case _                 => false
       }
-      if (up) {
+
+      if (predictionState.element.exists(isLiteralList)) {
         predictionState.predecessorStates
       } else {
-        super.initVisit(predictionState)
+        val precedingListLiterals =
+          predictionState.predecessorStates.filter(_.element.exists(isLiteralList))
+        if (precedingListLiterals.nonEmpty) {
+          precedingListLiterals
+        } else
+          super.initVisit(predictionState)
       }
     }
 

--- a/diesel/shared/src/test/scala/diesel/PredictionPropagationTest.scala
+++ b/diesel/shared/src/test/scala/diesel/PredictionPropagationTest.scala
@@ -241,10 +241,11 @@ class PredictionPropagationTest extends FunSuite {
             }
           if (accept) {
             val propagate = predictionState.element match {
-              case Some(DslSyntax(syntax)) if syntax == MyDsl.is      => true
-              case Some(DslSyntax(syntax)) if syntax == MyDsl.isOneOf => true
-              case Some(DslSyntax(syntax: SyntaxTyped[_]))            => syntax.name == "elvis"
-              case _                                                  => false
+              case Some(DslSyntax(syntax)) if syntax == MyDsl.is                      => true
+              case Some(DslSyntax(syntax)) if syntax == MyDsl.isOneOf                 => true
+              case Some(DslSyntax(syntax: SyntaxTyped[_])) if syntax.name == "elvis"  => true
+              case Some(DslSyntax(syntax: Syntax[_])) if syntax.name == "listLiteral" => true
+              case _                                                                  => false
             }
             if (propagate) {
               val propagates = predictionState.subIndex.filter(_ > 0)
@@ -551,6 +552,20 @@ class PredictionPropagationTest extends FunSuite {
 
   test("predict after comma in literal list") {
     val text = "\"foo\" is one of { \"bar\",  "
+    assertPredictions(
+      MyDsl.value,
+      text,
+      text.length,
+      Seq(
+        "ANumberValue(0)",
+        "AStringValue()",
+        "AVarRef(x)"
+      )
+    )
+  }
+
+  test("predict inside literal list") {
+    val text = "{ \"foo\",  "
     assertPredictions(
       MyDsl.value,
       text,


### PR DESCRIPTION
The example of literal list predictions requires the compute filter to use predecessor prediction states.

We are headed towards replacing prediction states by a tree.