### PR TITLE
Protect from infinite loop when precedences are incompatible in error recovery

### DIFF
--- a/diesel/shared/src/main/scala/diesel/Earley.scala
+++ b/diesel/shared/src/main/scala/diesel/Earley.scala
@@ -94,7 +94,13 @@ case class Earley(bnf: Bnf, dynamicLexer: Boolean = false) {
         errorRecovery(index, lexicalValue, context)
         if (lexicalValue.id == Lexer.Eos) {
           while (!context.success) {
+            val stateCount = context.stateCount()
             errorRecovery(index, lexicalValue, context)
+            if (stateCount == context.stateCount() && !context.success) {
+              throw new RuntimeException(
+                "internal error, unable to recover from errors"
+              )
+            }
           }
         }
       }

--- a/diesel/shared/src/main/scala/diesel/EarleyState.scala
+++ b/diesel/shared/src/main/scala/diesel/EarleyState.scala
@@ -283,6 +283,8 @@ class Result(val bnf: Bnf, val axiom: Bnf.Axiom) {
 
   private def successState(length: Int): State = State(axiom.production, 0, length, 1)
 
+  private[diesel] def stateCount(): Int = states.size
+
   private var currentChart: Option[Chart]                             = None
   private val nullableCache: mutable.Map[Bnf.NonTerminal, Set[State]] = mutable.Map()
 

--- a/diesel/shared/src/test/scala/diesel/ErrorRecoveryTest.scala
+++ b/diesel/shared/src/test/scala/diesel/ErrorRecoveryTest.scala
@@ -1,0 +1,168 @@
+/*
+ * Copyright 2024 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diesel
+
+import diesel.Dsl.{Axiom, Concept, Syntax}
+import diesel.Marker.{Descriptor, Kind, Severity}
+
+object ErrorRecoveryTestDsl {
+
+  object Ast {
+    sealed trait Value
+
+    case class NumberValue(f: Int) extends Value {
+      override def toString: String = f.toString
+    }
+
+    case class StringValue(s: String) extends Value
+
+    case class Add(left: Value, right: Value) extends Value
+
+    case class Sub(left: Value, right: Value) extends Value
+
+    case class Concat(left: Value, right: Value) extends Value
+  }
+
+  import Ast._
+
+  object MyDsl extends Dsl {
+
+    val objectConcept: Concept[Value] = concept[Value]
+
+    val numberConcept: Concept[Value] = concept[Value, Value](objectConcept)
+
+    val stringConcept: Concept[Value] = concept[Value, Value](objectConcept)
+
+    val intConcept: Concept[NumberValue] =
+      concept("\\d+".r, NumberValue(0), parent = Some(numberConcept)) map {
+        case (_, s) =>
+          NumberValue(s.text.toInt)
+      }
+
+    val textConcept: Concept[StringValue] =
+      concept("\"[^\"]*\"".r, StringValue(""), parent = Some(stringConcept)) map {
+        case (_, s) =>
+          StringValue(s.text.substring(1, s.text.length - 1))
+      }
+
+    val add: Syntax[Value] = syntax(numberConcept, hierarchical = true)(
+      numberConcept ~ "+".leftAssoc(10) ~ numberConcept map {
+        case (_, (n1, _, n2)) =>
+          Add(n1, n2)
+      }
+    )
+
+    val sub: Syntax[Value] = syntax(numberConcept, hierarchical = true)(
+      numberConcept ~ "-".leftAssoc(10) ~ numberConcept map {
+        case (_, (n1, _, n2)) =>
+          Sub(n1, n2)
+      }
+    )
+
+    val concat: Syntax[Value] = syntax(stringConcept, hierarchical = true)(
+      stringConcept ~ "+".leftAssoc(10) ~ stringConcept map {
+        case (_, (n1, _, n2)) =>
+          Concat(n1, n2)
+      }
+    )
+
+    val concat2: Syntax[Value] = syntax(stringConcept, hierarchical = true)(
+      numberConcept ~ "+".leftAssoc(10) ~ stringConcept map {
+        case (_, (n1, _, n2)) =>
+          Concat(n1, n2)
+      }
+    )
+
+    val concat3: Syntax[Value] = syntax(stringConcept, hierarchical = true)(
+      stringConcept ~ "+".leftAssoc(10) ~ numberConcept map {
+        case (_, (n1, _, n2)) =>
+          Concat(n1, n2)
+      }
+    )
+
+    val axiom: Axiom[Value] = axiom(objectConcept)
+  }
+}
+
+class ErrorRecoveryTest extends DslTestFunSuite {
+
+  import ErrorRecoveryTestDsl.Ast._
+
+  type Ast = Value
+  override def dsl: ErrorRecoveryTestDsl.MyDsl.type = ErrorRecoveryTestDsl.MyDsl
+
+  private val syntacticError = Descriptor(Kind.Syntactic, Severity.Error)
+  private val semanticError  = Descriptor(Kind.Semantic, Severity.Error)
+
+  test("number") {
+    assertAst("1") {
+      NumberValue(1)
+    }
+  }
+
+  test("string") {
+    assertAst("\"foo\"") {
+      StringValue("foo")
+    }
+  }
+
+  test("add") {
+    assertAst("1 + 2") {
+      Add(NumberValue(1), NumberValue(2))
+    }
+  }
+
+  test("add2") {
+    assertAst("1 + 2 + 3") {
+      Add(Add(NumberValue(1), NumberValue(2)), NumberValue(3))
+    }
+  }
+
+  test("sub") {
+    assertAst("1 - 2") {
+      Sub(NumberValue(1), NumberValue(2))
+    }
+  }
+
+  test("concat") {
+    assertAst("\"foo\" + \"bar\"") {
+      Concat(StringValue("foo"), StringValue("bar"))
+    }
+  }
+
+  test("concat2") {
+    assertAst("12 + \"bar\"") {
+      Concat(NumberValue(12), StringValue("bar"))
+    }
+  }
+
+  test("concat3") {
+    assertAst("\"foo\" + 14") {
+      Concat(StringValue("foo"), NumberValue(14))
+    }
+  }
+
+  test("incompatible") {
+    val ex = intercept[RuntimeException](AstHelpers.parse(dsl, "\"foo\" + 14 - 12"))
+    assert(ex.getMessage == "internal error, unable to recover from errors")
+  }
+
+  test("incomplete") {
+    val ex = intercept[RuntimeException](AstHelpers.parse(dsl, "\"foo\" + 14 - "))
+    assert(ex.getMessage == "internal error, unable to recover from errors")
+  }
+}

--- a/diesel/shared/src/test/scala/diesel/ErrorRecoveryTest.scala
+++ b/diesel/shared/src/test/scala/diesel/ErrorRecoveryTest.scala
@@ -1,5 +1,5 @@
 /*
- * Copyright 2024 The Diesel Authors
+ * Copyright 2018 The Diesel Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.


### PR DESCRIPTION
Raising a runtime exception, for low.

Later, error recovery will recognize precedences.