### PR TITLE
Introduce styled token listener to collect comments

### DIFF
--- a/diesel/shared/src/main/scala/diesel/AstHelpers.scala
+++ b/diesel/shared/src/main/scala/diesel/AstHelpers.scala
@@ -17,18 +17,25 @@
 package diesel
 
 import diesel.Dsl.Axiom
+import diesel.Dsl.Comments
+import diesel.Lexer.Token
 
 object AstHelpers {
 
   def parse(
     dsl: Dsl,
     text: String,
-    axiom: Option[Axiom[_]] = None
+    axiom: Option[Axiom[_]] = None,
+    onCommentToken: Option[Token => Unit] = None
   ): Result = {
-    val bnf: Bnf       = Bnf(dsl)
-    val parser: Earley = Earley(bnf, dsl.dynamicLexer)
-    val a              = getBnfAxiomOrThrow(bnf, axiom)
-    parser.parse(new Lexer.Input(text), a)
+    val bnf: Bnf            = Bnf(dsl)
+    val parser: Earley      = Earley(bnf, dsl.dynamicLexer)
+    val a                   = getBnfAxiomOrThrow(bnf, axiom)
+    val styledTokenListener = dsl match {
+      case c: Comments => onCommentToken.map(c.commentTokenListener)
+      case _           => None
+    }
+    parser.parse(new Lexer.Input(text, styledTokenListener), a)
   }
 
   def getBnfAxiomOrThrow(bnf: Bnf, axiom: Option[Axiom[_]]): Bnf.Axiom = {
@@ -68,9 +75,10 @@ object AstHelpers {
   def assertAsts(
     dsl: Dsl,
     axiom: Option[Axiom[_]] = None,
-    navigatorFactory: Result => Navigator = Navigator(_)
+    navigatorFactory: Result => Navigator = Navigator(_),
+    onCommentToken: Option[Token => Unit] = None
   )(s: String)(f: Navigator => Unit): Unit = {
-    val result    = parse(dsl, s, axiom)
+    val result    = parse(dsl, s, axiom, onCommentToken)
     assert(result.success)
     val navigator = navigatorFactory(result)
     f(navigator)

--- a/diesel/shared/src/main/scala/diesel/Dsl.scala
+++ b/diesel/shared/src/main/scala/diesel/Dsl.scala
@@ -22,6 +22,7 @@ import diesel.i18n.DeclaringSourceName
 import scala.language.implicitConversions
 import scala.reflect.ClassTag
 import scala.util.matching.Regex
+import diesel.Lexer.StyledTokenListener
 
 /** Type definitions of the Dsl API
   */
@@ -719,8 +720,14 @@ object Dsl {
    */
 
   trait Comments {
-
     def commentScanners: Seq[Scanner]
+    def commentStyle: Option[Style]                                 = Option.empty
+    def commentTokenListener(f: Token => Unit): StyledTokenListener = { case (t, styles) =>
+      val hasCommentStyle = commentStyle.exists(styles.contains)
+      if (hasCommentStyle) {
+        f(t)
+      }
+    }
   }
 
   /*

--- a/diesel/shared/src/main/scala/diesel/Lexer.scala
+++ b/diesel/shared/src/main/scala/diesel/Lexer.scala
@@ -68,7 +68,9 @@ object Lexer {
     def name: String = c.name
   }
 
-  class Input(var s: String) {
+  type StyledTokenListener = (Token, Seq[Style]) => Unit
+
+  class Input(var s: String, styledTokenListener: Option[StyledTokenListener] = None) {
     private var pos: Int = 0
 
     def offset: Int = pos
@@ -83,6 +85,9 @@ object Lexer {
     }
 
     def eos: Boolean = s.isEmpty
+
+    def onStyledToken(t: Token, styles: Seq[Style]): Unit =
+      styledTokenListener.foreach(_.apply(t, styles))
   }
 
   trait Scanner {
@@ -291,7 +296,11 @@ object Lexer {
     dsl match {
       case comments: Comments =>
         comments.commentScanners.foreach { regex =>
-          rules = rules ++ Seq(SimpleRule(regex, Skip))
+          rules = rules ++ Seq(SimpleRule(
+            regex,
+            Skip,
+            styles = comments.commentStyle.toSeq
+          ))
         }
       case _                  => ()
     }
@@ -311,7 +320,10 @@ object Lexer {
   }
 }
 
-case class Lexer(lexerRules: Seq[Rule], tokenRules: Map[TokenId, Rule]) {
+case class Lexer(
+  lexerRules: Seq[Rule],
+  tokenRules: Map[TokenId, Rule]
+) {
 
   import diesel.Lexer._
 
@@ -385,12 +397,14 @@ case class Lexer(lexerRules: Seq[Rule], tokenRules: Map[TokenId, Rule]) {
         case None =>
           (Token(input.offset, if (eatOnError) input.eat(1) else "", Error), Seq())
 
-        case Some(((Token(_, text, Skip), _), _)) =>
+        case Some(((t @ Token(_, text, Skip), styles), _)) =>
           input.eat(text.length)
+          input.onStyledToken(t, styles)
           next(input, lexerRules, eatOnError)
 
-        case Some((res @ (Token(_, text, _), _), _)) =>
+        case Some((res @ (t @ Token(_, text, _), styles), _)) =>
           input.eat(text.length)
+          input.onStyledToken(t, styles)
           res
       }
     }

--- a/diesel/shared/src/test/scala/diesel/StyledCommentsTest.scala
+++ b/diesel/shared/src/test/scala/diesel/StyledCommentsTest.scala
@@ -1,0 +1,79 @@
+/*
+ * Copyright 2018 The Diesel Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package diesel
+
+import diesel.Dsl.Axiom
+import diesel.Dsl.Concept
+import diesel.Dsl.Identifiers
+import diesel.Dsl.Syntax
+import diesel.Lexer.Scanner
+import munit.FunSuite
+import scala.collection.mutable.ArrayBuffer
+import diesel.Lexer.Token
+
+class StyledCommentsTest extends FunSuite {
+
+  object MyDsl extends Dsl with Identifiers with Dsl.Comments {
+
+    case object CommentStyle extends Style {
+      val name = "myComment"
+    }
+
+    override def commentScanners: Seq[Scanner] = Seq(
+      "//[^\n]*(\n|$)".r
+    )
+    override def commentStyle: Option[Style]   = Some(CommentStyle)
+
+    override def identScanner: Lexer.Scanner = "[a-zA-Z_][a-zA-Z0-9_]*".r
+
+    val c: Concept[String] = concept
+
+    val s: Syntax[String] = syntax(c)(id map { case (_, t) => t.text })
+
+    val a: Axiom[String] = axiom(c)
+  }
+
+  val commentTokens: ArrayBuffer[Token] = new ArrayBuffer()
+  private def onComment(t: Token): Unit = {
+    commentTokens.append(t)
+  }
+
+  test("no comment") {
+    AstHelpers.assertAsts(MyDsl, onCommentToken = Some(onComment))("foo") { navigator =>
+      assertEquals(navigator.next().value, "foo")
+      assertEquals(
+        commentTokens.toSeq.map(t => (t.offset, t.length)),
+        Seq()
+      )
+    }
+  }
+  test("with comment") {
+    AstHelpers.assertAsts(MyDsl, onCommentToken = Some(onComment))("""
+                                                                     |// first comment
+                                                                     |foo // more comment
+                                                                     |// last comment
+                                                                     |""".stripMargin) {
+      navigator =>
+        assertEquals(navigator.next().value, "foo")
+        assertEquals(
+          commentTokens.toSeq.map(t => (t.offset, t.length)),
+          Seq((1, 17), (22, 16), (38, 16))
+        )
+    }
+  }
+
+}


### PR DESCRIPTION
Use Comments trait to declare a Style for comments,
and add a dedicated styled token listener to the parsers input to record those comment tokens.

